### PR TITLE
Fix error "attempt to call method 'SteamID'"

### DIFF
--- a/lua/autorun/client/cl_cfc_chatblock.lua
+++ b/lua/autorun/client/cl_cfc_chatblock.lua
@@ -44,7 +44,7 @@ local function updateFile()
 end
 
 hook.Add( "OnPlayerChat", "CFC_ChatBlock_CheckPlayer", function( ply )
-    if not ply:IsPlayer() then return end
+    if not IsValid( ply ) or not ply:IsPlayer() then return end
     if blockedPlayers[ply:SteamID()] then
         return true
     end

--- a/lua/autorun/client/cl_cfc_chatblock.lua
+++ b/lua/autorun/client/cl_cfc_chatblock.lua
@@ -44,6 +44,7 @@ local function updateFile()
 end
 
 hook.Add( "OnPlayerChat", "CFC_ChatBlock_CheckPlayer", function( ply )
+    if not ply:IsPlayer() then return end
     if blockedPlayers[ply:SteamID()] then
         return true
     end


### PR DESCRIPTION
[cfc_chatblock] addons/cfc_chatblock/lua/autorun/client/cl_cfc_chatblock.lua:47: attempt to call method 'SteamID' (a nil value)
    1. fn - addons/cfc_chatblock/lua/autorun/client/cl_cfc_chatblock.lua:47
        2. Run - addons/ulib/lua/ulib/shared/hook.lua:109
            3. func - addons/betterchat/lua/betterchat/client/formatting.lua:474
                4. unknown - lua/includes/extensions/net.lua:32